### PR TITLE
Fix for throwing exception when opening file with Unicode file name.

### DIFF
--- a/playsound.py
+++ b/playsound.py
@@ -16,10 +16,11 @@ def _playsoundWin(sound, block = True):
     from ctypes import c_buffer, windll
     from random import random
     from time   import sleep
+    from sys    import getfilesystemencoding
 
     def winCommand(*command):
         buf = c_buffer(255)
-        command = ' '.join(command).encode()
+        command = ' '.join(command).encode(getfilesystemencoding())
         errorCode = int(windll.winmm.mciSendStringA(command, buf, 254, 0))
         if errorCode:
             errorBuffer = c_buffer(255)


### PR DESCRIPTION
I saw your pull request to [TaylorSMarks/playsound](https://github.com/TaylorSMarks/playsound/pull/3) and thanks for your work it's just work fine with me on Windows 10.

But i found out when I pass the path with Unicode it will throw 'Cannot find the specified file' exception. So this PR fix this. And wish your pull request will be merge into master. Thanks.